### PR TITLE
[DOC] Unregistered Package != Private Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ POD globally solves a given MINLP by:
 
 ## Installation
 
-POD is a currently a private repository under the LANL-ANSI group, which can be installed through the Julia package manager:
+POD is a currently a unregistered package, with it's repository under the LANL-ANSI group, which can be installed through the Julia package manager:
 
 `Pkg.clone("https://github.com/lanl-ansi/POD.git")`
 


### PR DESCRIPTION
Very very minor change to the README here.
_Private repository_ is a [specific term in github land.](https://help.github.com/articles/making-a-public-repository-private/)

This is not a private repository (as I can see it).
It is repository for an unregistered package.

Cool package BTW. :-D
