### PR TITLE
Replaced Pajarito solver with Pavito solver to fix tests

### DIFF
--- a/src/utility.jl
+++ b/src/utility.jl
@@ -694,6 +694,9 @@ function fetch_mip_solver_identifier(m::PODNonlinearModel;override="")
     if contains(solverstring,"Pajarito")
         m.mip_solver_id = "Pajarito"
         return
+    elseif contains(solverstring, "Pavito")
+        m.mip_solver_id = "Pavito"
+        return
     end
 
     # Lower level solvers
@@ -719,6 +722,9 @@ function fetch_nlp_solver_identifier(m::PODNonlinearModel;override="")
     # Higher-level solver
     if contains(solverstring, "Pajarito")
         m.nlp_solver_id = "Pajarito"
+        return
+    elseif contains(solverstring, "Pavito")
+        m.nlp_solver_id = "Pavito"
         return
     end
 
@@ -747,6 +753,9 @@ function fetch_minlp_solver_identifier(m::PODNonlinearModel;override="")
     # Higher-level solver
     if contains(solverstring, "Pajarito")
         m.minlp_solver_id = "Pajarito"
+        return
+    elseif contains(solverstring, "Pavito")
+        m.minlp_solver_id = "Pavito"
         return
     end
 
@@ -779,6 +788,8 @@ function update_mip_time_limit(m::PODNonlinearModel; kwargs...)
 
     if m.mip_solver_id == "CPLEX"
         insert_timeleft_symbol(m.mip_solver.options,timelimit,:CPX_PARAM_TILIM,m.timeout)
+    elseif m.mip_solver_id == "Pavito"
+        (timelimit < Inf) && (m.mip_solver.timeout = timelimit)
     elseif m.mip_solver_id == "Gurobi"
         insert_timeleft_symbol(m.mip_solver.options,timelimit,:TimeLimit,m.timeout)
     elseif m.mip_solver_id == "Cbc"
@@ -834,6 +845,8 @@ function update_minlp_time_limit(m::PODNonlinearModel; kwargs...)
     haskey(options, :timelimit) ? timelimit = options[:timelimit] : timelimit = max(0.0, m.timeout-m.logs[:total_time])
 
     if m.minlp_solver_id == "Pajarito"
+        (timelimit < Inf) && (m.minlp_solver.timeout = timelimit)
+    elseif m.minlp_solver_id == "Pavito"
         (timelimit < Inf) && (m.minlp_solver.timeout = timelimit)
     elseif m.minlp_solver_id == "AmplNL"
         insert_timeleft_symbol(m.minlp_solver.options,timelimit,:seconds,m.timeout,options_string_type=2)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -3,5 +3,5 @@ JuMP
 MathProgBase
 Ipopt
 Cbc
-Pajarito
+Pavito
 GLPKMathProgInterface

--- a/test/algorithm.jl
+++ b/test/algorithm.jl
@@ -1,7 +1,7 @@
 @testset " Validation Test || AMP-TMC || basic solve || exampls/nlp1.jl" begin
 
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                       mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                       mip_solver=pavito_solver,
                        bilinear_convexhull=false,
                        monomial_convexhull=false,
                        presolve_bt=false,
@@ -61,7 +61,7 @@ end
 @testset " Validation Test || PBT-AMP-TMC || basic solve || exampls/nlp1.jl" begin
 
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-							   mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+							   mip_solver=pavito_solver,
                                bilinear_convexhull=false,
                                monomial_convexhull=false,
 							   presolve_bt=true,
@@ -104,7 +104,7 @@ end
 @testset " Validation Test || PBT-AMP-TMC || basic solve || examples/nlp3.jl" begin
 
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                               mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                               mip_solver=pavito_solver,
                                bilinear_convexhull=false,
                                loglevel=100,
                                maxiter=2,
@@ -125,7 +125,7 @@ end
 
 @testset " Validation Test || AMP-CONV || basic solve || examples/nlp1.jl" begin
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                       mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                       mip_solver=pavito_solver,
                        bilinear_convexhull=true,
                        monomial_convexhull=true,
                        presolve_bt=false,
@@ -141,7 +141,7 @@ end
 
 @testset " Validation Test || PBT-AMP-CONV || basic solve || examples/nlp1.jl" begin
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                       mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                       mip_solver=pavito_solver,
                        bilinear_convexhull=true,
                        monomial_convexhull=true,
                        presolve_bt=true,
@@ -174,7 +174,7 @@ end
 
 @testset " Validation Test || AMP || basic solve || examples/circle.jl" begin
     test_solver=PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                           mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                           mip_solver=pavito_solver,
                            disc_abs_width_tol=1e-2,
                            disc_ratio=8,
                            maxiter=6,
@@ -191,7 +191,7 @@ end
 
 @testset " Validation Test || AMP || basic solve || examples/circleN.jl" begin
     test_solver=PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                           mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                           mip_solver=pavito_solver,
                            disc_abs_width_tol=1e-2,
                            disc_ratio=8,
                            presolve_bt = false,
@@ -206,7 +206,7 @@ end
 
 @testset " Validation Test || AMP-CONV-FACET || basic solve || examples/nlp1.jl" begin
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                       mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                       mip_solver=pavito_solver,
                        bilinear_convexhull=true,
                        monomial_convexhull=true,
                        presolve_bt=false,
@@ -223,7 +223,7 @@ end
 
 @testset " Validation Test || AMP-CONV-MINIB || basic solve || examples/nlp1.jl" begin
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                       mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                       mip_solver=pavito_solver,
                        bilinear_convexhull=true,
                        monomial_convexhull=true,
                        presolve_bt=false,
@@ -484,9 +484,7 @@ end
 end
 
 @testset "Operator :: bmpl && binlin && binprod solve test I" begin
-    test_solver=PODSolver(minlp_solver=PajaritoSolver(mip_solver=CbcSolver(logLevel=0),
-                                                          cont_solver=IpoptSolver(print_level=0),
-                                                          log_level=0),
+    test_solver=PODSolver(minlp_solver=pavito_solver,
                           nlp_solver=IpoptSolver(print_level=0),
                           mip_solver=CbcSolver(logLevel=0),
                           loglevel=100)
@@ -508,9 +506,7 @@ end
 end
 
 @testset "Operator :: bmpl && binlin && binprod solve test II" begin
-    test_solver=PODSolver(minlp_solver=PajaritoSolver(mip_solver=CbcSolver(logLevel=0),
-                                                          cont_solver=IpoptSolver(print_level=0),
-                                                          log_level=0),
+    test_solver=PODSolver(minlp_solver=pavito_solver,
                           nlp_solver=IpoptSolver(print_level=0),
                           mip_solver=CbcSolver(logLevel=0),
                           loglevel=100)
@@ -543,13 +539,9 @@ end
 end
 
 @testset "Operator :: bmpl && binlin && binprod solve test II" begin
-    test_solver=PODSolver(minlp_solver=PajaritoSolver(mip_solver=CbcSolver(logLevel=0),
-                                                          cont_solver=IpoptSolver(print_level=0),
-                                                          log_level=0),
+    test_solver=PODSolver(minlp_solver=pavito_solver,
                           nlp_solver=IpoptSolver(print_level=0),
-                          mip_solver=PajaritoSolver(mip_solver=CbcSolver(logLevel=0),
-                                                    cont_solver=IpoptSolver(print_level=0),
-                                                    log_level=0),
+                          mip_solver=pavito_solver,
                           disc_var_pick=1,
                           loglevel=100)
 
@@ -605,13 +597,9 @@ end
 end
 
 @testset "Operator :: bmpl && binlin && binprod solve test III with negative bounds" begin
-    test_solver=PODSolver(minlp_solver=PajaritoSolver(mip_solver=CbcSolver(logLevel=0),
-                                                          cont_solver=IpoptSolver(print_level=0),
-                                                          log_level=0),
+    test_solver=PODSolver(minlp_solver=pavito_solver,
                           nlp_solver=IpoptSolver(print_level=0),
-                          mip_solver=PajaritoSolver(mip_solver=CbcSolver(logLevel=0),
-                                                    cont_solver=IpoptSolver(print_level=0),
-                                                    log_level=0),
+                          mip_solver=pavito_solver,
                           disc_var_pick=1,
                           loglevel=100)
 
@@ -646,7 +634,7 @@ end
 
 @testset "Embedding Test || AMP-CONV || basic solve || examples/nlp1.jl" begin
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                       mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                       mip_solver=pavito_solver,
                        bilinear_convexhull=true,
                        monomial_convexhull=true,
                        presolve_bt=false,
@@ -663,7 +651,7 @@ end
 
 @testset "Embedding Test || PBT-AMP-CONV || basic solve || examples/nlp1.jl" begin
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                       mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                       mip_solver=pavito_solver,
                        bilinear_convexhull=true,
                        monomial_convexhull=true,
                        presolve_bt=true,
@@ -698,7 +686,7 @@ end
 
 @testset "Embedding Test || AMP || special problem || ... " begin
     test_solver=PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                           mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                           mip_solver=pavito_solver,
                            disc_abs_width_tol=1e-2,
                            disc_ratio=8,
                            maxiter=6,
@@ -716,7 +704,7 @@ end
 
 @testset "Embedding IBS Test || AMP-CONV || basic solve || examples/nlp1.jl" begin
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                       mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                       mip_solver=pavito_solver,
                        bilinear_convexhull=true,
                        monomial_convexhull=true,
                        presolve_bt=false,
@@ -752,7 +740,7 @@ end
 
 @testset "Embedding IBS Test || AMP || special problem || ... " begin
     test_solver=PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                           mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                           mip_solver=pavito_solver,
                            disc_abs_width_tol=1e-2,
                            disc_ratio=8,
                            maxiter=6,
@@ -771,7 +759,7 @@ end
 
 @testset "Embedding LINK Test || AMP-CONV || basic solve || examples/nlp1.jl" begin
     test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                       mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                       mip_solver=pavito_solver,
                        bilinear_convexhull=true,
                        monomial_convexhull=true,
                        presolve_bt=false,
@@ -807,7 +795,7 @@ end
 
 @testset "Embedding LINK Test || AMP || special problem || ... " begin
     test_solver=PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                           mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                           mip_solver=pavito_solver,
                            disc_abs_width_tol=1e-2,
                            disc_ratio=8,
                            maxiter=6,
@@ -839,7 +827,7 @@ end
 
 @testset " Algorithm Logic Test || blend029_gl || 3 iterations || Infeasible Case" begin
 
-    test_solver=PODSolver(minlp_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+    test_solver=PODSolver(minlp_solver=pavito_solver,
                           nlp_solver=IpoptSolver(print_level=0),
                           mip_solver=CbcSolver(logLevel=0),
                           presolve_bp=true,
@@ -858,7 +846,7 @@ end
 
 @testset "Convex Model Solve" begin
     test_solver=PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                           mip_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+                           mip_solver=pavito_solver,
                            maxiter=1,
                            colorful_pod="solarized",
                            loglevel=100)
@@ -883,7 +871,7 @@ end
 
 @testset "Algorithm Test with binprod terms" begin
 
-    test_solver = PODSolver(minlp_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+    test_solver = PODSolver(minlp_solver=pavito_solver,
                             nlp_solver=IpoptSolver(print_level=0),
                             mip_solver=CbcSolver(logLevel=0),
                             bilinear_convexhull=true,

--- a/test/expression.jl
+++ b/test/expression.jl
@@ -1186,7 +1186,7 @@ end
 @testset "Expression Prasing || Linear Lifting" begin
     @testset "Expression Parsing || Linear Lifting || nlp2" begin
         test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                               mip_solver=PajaritoSolver(mip_solver=CbcSolver(logLevel=0),cont_solver=IpoptSolver(print_level=0), log_level=0),
+                               mip_solver=CbcSolver(),
                                disc_ratio=8,
                                loglevel=100)
 
@@ -1405,7 +1405,7 @@ end
     @testset "Expression Parsing || Linear Lifting || brainpc3" begin
 
         test_solver = PODSolver(nlp_solver=IpoptSolver(print_level=0),
-                            mip_solver=PajaritoSolver(mip_solver=CbcSolver(logLevel=0),cont_solver=IpoptSolver(print_level=0), log_level=0),
+                            mip_solver=CbcSolver(),
                             disc_ratio=8,
                             loglevel=100)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Base.Test
 using JuMP, MathProgBase
-using Ipopt, Cbc, Pajarito
+using Ipopt, Cbc, Pavito
 using GLPKMathProgInterface
 using POD
 
@@ -10,6 +10,8 @@ examples = readdir(joinpath(Pkg.dir("POD"), "test", "examples"))
 for i in examples
     include(joinpath(Pkg.dir("POD"), "test", "examples", i))
 end
+
+pavito_solver=PavitoSolver(mip_solver=CbcSolver(logLevel=0), cont_solver=IpoptSolver(print_level=0), mip_solver_drives=false, log_level=0)
 
 # Performe Tests
 include("$(poddir)/test/solver.jl")

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -145,7 +145,7 @@ end
 @testset "Partitioning variable selection tests :: blend029" begin
 
     # Select all NL variable
-    test_solver = PODSolver(minlp_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+    test_solver = PODSolver(minlp_solver=pavito_solver,
                             nlp_solver=IpoptSolver(print_level=0),
                             mip_solver=CbcSolver(logLevel=0),
                             disc_var_pick=0,
@@ -162,7 +162,7 @@ end
     @test m.internalModel.disc_var_pick == 0
 
     # Minimum vertex cover
-    test_solver = PODSolver(minlp_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+    test_solver = PODSolver(minlp_solver=pavito_solver,
                             nlp_solver=IpoptSolver(print_level=0),
                             mip_solver=CbcSolver(logLevel=0),
                             disc_var_pick=1,
@@ -180,7 +180,7 @@ end
     @test m.internalModel.disc_var_pick == 1
 
     # Adaptive Scheme vertex cover
-    test_solver = PODSolver(minlp_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+    test_solver = PODSolver(minlp_solver=pavito_solver,
                             nlp_solver=IpoptSolver(print_level=0),
                             mip_solver=CbcSolver(logLevel=0),
                             disc_var_pick=2,

--- a/test/utility.jl
+++ b/test/utility.jl
@@ -1,6 +1,6 @@
 @testset "Utility Function Tests: Solver identifier fetch" begin
 
-    test_solver=PODSolver(minlp_solver=PajaritoSolver(cont_solver=IpoptSolver(print_level=0), mip_solver=CbcSolver(logLevel=0), log_level=0),
+    test_solver=PODSolver(minlp_solver=pavito_solver,
                           nlp_solver=IpoptSolver(print_level=0),
                           mip_solver=CbcSolver(logLevel=0),
                           presolve_bp=true,


### PR DESCRIPTION
The new update on Pajarito solver triggers an issue with POD tests when dependent NLP solver for Pajarito is derivative-based. Given the error message provided by Pajarito, we are replacing the Pajarito solver from the tests with Pavito solver.

@kaarthiksundar The version switch in test/REQUIRE doesn't seem to work when I tried to dial Pajarito back to 0.4.0. The bypass could be caused by a deeper inter-dependency requirement caused among test packages.